### PR TITLE
Fix for default black white space character showing up on non rails files 

### DIFF
--- a/geany/filedefs/filetypes.common
+++ b/geany/filedefs/filetypes.common
@@ -51,7 +51,7 @@ indent_guide=0x393939;0x1E1E1E;false;false
 
 # third argument: if true, use this foreground color. If false, use the default value defined by the filetypes.
 # fourth argument: if true, use this background color. If false, use the default value defined by the filetypes.
-white_space=0x343232;0x1E1E1E;true;true
+#white_space=0x343232;0x1E1E1E;true;true
 
 # style of folding icons, only first and second arguments are used, valid values are:
 # first argument:  1 for boxes, 2 for circles


### PR DESCRIPTION
by default on a white background, a python file, for example, would have the white space styled as  black. 

STR. 
1. open a python file with file extension .py
2. notice that whitespace is coloured as black squares

In this commit, we simply  comment out this overwritten default colour. 
